### PR TITLE
Refactor log buffer to use template-based size configuration

### DIFF
--- a/include/log_dispatcher.hpp
+++ b/include/log_dispatcher.hpp
@@ -209,15 +209,15 @@ struct log_line_dispatcher
     void update_sink_config(std::unique_ptr<sink_config> new_config);
 
     // Worker thread helper methods
-    size_t dequeue_buffers(moodycamel::ConsumerToken& token, log_buffer** buffers, bool wait);
-    size_t process_buffer_batch(log_buffer** buffers, size_t start_idx, size_t count, sink_config* config);
-    bool process_queue(log_buffer** buffers, size_t dequeued_count, sink_config* config);
+    size_t dequeue_buffers(moodycamel::ConsumerToken& token, log_buffer_base** buffers, bool wait);
+    size_t process_buffer_batch(log_buffer_base** buffers, size_t start_idx, size_t count, sink_config* config);
+    bool process_queue(log_buffer_base** buffers, size_t dequeued_count, sink_config* config);
     void drain_queue(moodycamel::ConsumerToken& token);
 
 #ifdef LOG_COLLECT_DISPATCHER_METRICS
     // Helper functions for statistics collection
     void update_batch_stats(size_t dequeued_count);
-    void track_inflight_times(log_buffer **buffers, size_t start_idx, size_t count);
+    void track_inflight_times(log_buffer_base **buffers, size_t start_idx, size_t count);
     void update_dispatch_timing_stats(std::chrono::steady_clock::time_point start, size_t message_count);
     void update_message_rate_sample();
 
@@ -284,7 +284,7 @@ struct log_line_dispatcher
     bool has_default_sink_{true}; // Flag to track if we still have the default stdout sink // Only for modifications
 
     // Async processing members
-    moodycamel::BlockingConcurrentQueue<log_buffer *> queue_;
+    moodycamel::BlockingConcurrentQueue<log_buffer_base *> queue_;
     std::thread worker_thread_;
     std::atomic<bool> shutdown_{false};
 

--- a/include/log_formatters.hpp
+++ b/include/log_formatters.hpp
@@ -34,9 +34,9 @@ class nop_formatter
   public:
     bool do_copy = false;
 
-    size_t calculate_size(const log_buffer *buffer) const { return buffer ? buffer->len() : 0; }
+    size_t calculate_size(const log_buffer_base *buffer) const { return buffer ? buffer->len() : 0; }
 
-    size_t format(const log_buffer *buffer, char *output, size_t max_size) const
+    size_t format(const log_buffer_base *buffer, char *output, size_t max_size) const
     {
         if (!buffer || max_size == 0) return 0;
 
@@ -59,7 +59,7 @@ class raw_formatter
     bool use_color   = true;
     bool add_newline = false;
 
-    size_t calculate_size(const log_buffer *buffer) const
+    size_t calculate_size(const log_buffer_base *buffer) const
     {
         if (!buffer) return 0;
 
@@ -106,7 +106,7 @@ class raw_formatter
         return size;
     }
 
-    size_t format(const log_buffer *buffer, char *output, size_t max_size) const
+    size_t format(const log_buffer_base *buffer, char *output, size_t max_size) const
     {
         if (!buffer) return 0;
 
@@ -249,7 +249,7 @@ class taocpp_json_formatter
      * This method follows taocpp/json's producer pattern, making it reusable
      * with different consumers (size calculation, formatting, etc.)
      */
-    template <typename Consumer> void produce_log_json(Consumer &c, const log_buffer *buffer) const
+    template <typename Consumer> void produce_log_json(Consumer &c, const log_buffer_base *buffer) const
     {
         c.begin_object();
 
@@ -300,7 +300,7 @@ class taocpp_json_formatter
         c.end_object();
     }
 
-    size_t calculate_size(const log_buffer *buffer) const
+    size_t calculate_size(const log_buffer_base *buffer) const
     {
         if (!buffer) return 0;
 
@@ -347,7 +347,7 @@ class taocpp_json_formatter
         return size;
     }
 
-    size_t format(const log_buffer *buffer, char *output, size_t max_size) const
+    size_t format(const log_buffer_base *buffer, char *output, size_t max_size) const
     {
         if (!buffer || max_size == 0) return 0;
 

--- a/include/log_line.hpp
+++ b/include/log_line.hpp
@@ -30,7 +30,7 @@ namespace slwoggy
  */
 struct log_line
 {
-    log_buffer *buffer_;
+    log_buffer_base *buffer_;
     bool needs_header_{false}; // True after swap, header written on first write
 
     // Store these for endl support and header writing
@@ -352,7 +352,7 @@ struct log_line
     }
 
     // Swap buffer with a new one from pool, return old buffer
-    log_buffer *swap_buffer()
+    log_buffer_base *swap_buffer()
     {
         auto *old_buffer = buffer_;
         

--- a/include/log_structured.hpp
+++ b/include/log_structured.hpp
@@ -266,7 +266,7 @@ struct structured_log_key_registry
  *       statistics are incremented (see get_drop_stats()).
  */
 // Forward declaration
-struct log_buffer;
+class log_buffer_base;
 
 class log_buffer_metadata_adapter
 {
@@ -286,10 +286,10 @@ class log_buffer_metadata_adapter
     };
 
   private:
-    log_buffer* buffer_;
+    log_buffer_base* buffer_;
 
   public:
-    log_buffer_metadata_adapter(log_buffer* buffer) : buffer_(buffer) {}
+    log_buffer_metadata_adapter(log_buffer_base* buffer) : buffer_(buffer) {}
 
     void reset();
     bool add_kv(uint16_t key_id, std::string_view value);
@@ -318,9 +318,10 @@ class log_buffer_metadata_adapter
     {
         const char *current_;
         const char *end_;
+        uint8_t remaining_count_;
         
     public:
-        iterator(const char *start, const char *end);
+        iterator(const char *start, const char *end, uint8_t count);
         bool has_next() const;
         kv_pair next();
     };

--- a/include/log_types.hpp
+++ b/include/log_types.hpp
@@ -34,8 +34,7 @@ inline constexpr size_t MAX_DISPATCH_QUEUE_SIZE = 16 * 1024; // Max # buffers wa
 inline constexpr auto BATCH_COLLECT_TIMEOUT = std::chrono::microseconds(100); // Max time to collect a batch
 inline constexpr auto BATCH_POLL_INTERVAL   = std::chrono::microseconds(10);  // Polling interval when collecting
 
-// Log buffer constants
-inline constexpr size_t LOG_BUFFER_SIZE       = 2048;
+// Structured logging constants
 inline constexpr uint32_t MAX_STRUCTURED_KEYS = 256; // Maximum structured keys
 inline constexpr size_t MAX_FORMATTED_SIZE    = 128; // max size of values when allowed in the metadata
 

--- a/include/log_writers.hpp
+++ b/include/log_writers.hpp
@@ -102,7 +102,7 @@ class writev_file_writer : public file_writer
 
     // Bulk write implementation using writev
     template <typename Formatter>
-    size_t bulk_write(log_buffer **buffers, size_t count, const Formatter &formatter) const
+    size_t bulk_write(log_buffer_base **buffers, size_t count, const Formatter &formatter) const
     {
         if (fd_ < 0 || count == 0) return 0;
 
@@ -118,7 +118,7 @@ class writev_file_writer : public file_writer
         size_t i;
         for (i = 0; i < count && iov_count < MAX_IOV; ++i)
         {
-            log_buffer *buf = buffers[i];
+            log_buffer_base *buf = buffers[i];
 
             // Skip empty buffers
             if (buf->len() == 0) continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,14 +283,14 @@ int main(int argc, char *argv[])
             std::cerr << "  Total buffer usage:\n";
             std::cerr << "    Min: " << pool_stats.total_usage.min_bytes << " bytes ("
                       << std::fixed << std::setprecision(1) 
-                      << (pool_stats.total_usage.min_bytes * 100.0 / LOG_BUFFER_SIZE) << "%)\n";
+                      << (pool_stats.total_usage.min_bytes * 100.0 / buffer_pool::BUFFER_SIZE) << "%)\n";
             std::cerr << "    Max: " << pool_stats.total_usage.max_bytes << " bytes ("
                       << std::fixed << std::setprecision(1) 
-                      << (pool_stats.total_usage.max_bytes * 100.0 / LOG_BUFFER_SIZE) << "%)\n";
+                      << (pool_stats.total_usage.max_bytes * 100.0 / buffer_pool::BUFFER_SIZE) << "%)\n";
             std::cerr << "    Avg: " << std::fixed << std::setprecision(1) 
                       << pool_stats.total_usage.avg_bytes << " bytes ("
                       << std::fixed << std::setprecision(1) 
-                      << (pool_stats.total_usage.avg_bytes * 100.0 / LOG_BUFFER_SIZE) << "%)\n";
+                      << (pool_stats.total_usage.avg_bytes * 100.0 / buffer_pool::BUFFER_SIZE) << "%)\n";
             std::cerr << "    Samples: " << pool_stats.total_usage.sample_count << "\n";
         }
         std::cerr << "=========================================\n";

--- a/tests/test_log_statistics.cpp
+++ b/tests/test_log_statistics.cpp
@@ -60,7 +60,7 @@ TEST_CASE("Buffer pool statistics", "[statistics]") {
         REQUIRE(initial_stats.high_water_mark >= initial_stats.in_use_buffers);
         
         // Acquire 5 buffers
-        std::vector<log_buffer*> buffers;
+        std::vector<log_buffer_base*> buffers;
         const size_t acquire_count = 5;
         
         for (size_t i = 0; i < acquire_count; ++i) {
@@ -93,7 +93,7 @@ TEST_CASE("Buffer pool statistics", "[statistics]") {
         uint64_t initial_high_water = initial_stats.high_water_mark;
         
         // Acquire 50% of pool
-        std::vector<log_buffer*> buffers;
+        std::vector<log_buffer_base*> buffers;
         const size_t target_count = BUFFER_POOL_SIZE / 2;
         
         for (size_t i = 0; i < target_count; ++i) {
@@ -120,7 +120,7 @@ TEST_CASE("Buffer pool statistics", "[statistics]") {
     }
     
     SECTION("Pool exhaustion") {
-        std::vector<log_buffer*> buffers;
+        std::vector<log_buffer_base*> buffers;
         auto initial_stats = buffer_pool::instance().get_stats();
         
         // Try to acquire more than pool size
@@ -308,7 +308,7 @@ TEST_CASE("Structured logging drop statistics", "[statistics]") {
         
         // Try to add a value that would collide with text area
         // Fill buffer to leave minimal space
-        std::string text(LOG_BUFFER_SIZE - 100, 'x');
+        std::string text(buffer_pool::BUFFER_SIZE - 100, 'x');
         buffer->write_raw(text);
         
         std::string large_value(150, 'y');
@@ -342,7 +342,7 @@ TEST_CASE("Structured logging drop statistics", "[statistics]") {
         metadata.reset();
         
         // Fill most of the buffer with text to ensure metadata won't fit
-        std::string filler(LOG_BUFFER_SIZE - 100, 'x');
+        std::string filler(buffer_pool::BUFFER_SIZE - 100, 'x');
         buffer->write_raw(filler);
         
         // Now try to add oversized entries - they should fail due to collision
@@ -372,7 +372,7 @@ TEST_CASE("Structured logging drop statistics", "[statistics]") {
         REQUIRE(buffer != nullptr);
         
         // Fill buffer to force drops
-        std::string filler(LOG_BUFFER_SIZE - 50, 'x');
+        std::string filler(buffer_pool::BUFFER_SIZE - 50, 'x');
         buffer->write_raw(filler);
         
         auto metadata = buffer->get_metadata_adapter();

--- a/tests/test_log_structured.cpp
+++ b/tests/test_log_structured.cpp
@@ -28,17 +28,17 @@ public:
     public:
         capturing_formatter(test_structured_sink* parent) : parent_(parent) {}
         
-        size_t calculate_size(const log_buffer* buffer) const {
+        size_t calculate_size(const log_buffer_base* buffer) const {
             // We don't actually format, just capture
             return 0;
         }
         
-        size_t format(const log_buffer* buffer, char* output, size_t size) const {
+        size_t format(const log_buffer_base* buffer, char* output, size_t size) const {
             if (!buffer) return 0;
 
             fprintf(stderr, "Captured log: %s\n", buffer->get_text().data());
 
-            const_cast<log_buffer*>(buffer)->add_ref();
+            const_cast<log_buffer_base*>(buffer)->add_ref();
 
             captured_log entry;
             entry.level = buffer->level_;
@@ -65,7 +65,7 @@ public:
             }
             parent_->cv.notify_all();
 
-            const_cast<log_buffer*>(buffer)->release();
+            const_cast<log_buffer_base*>(buffer)->release();
             return 0;
         }
     };
@@ -232,7 +232,7 @@ TEST_CASE("Metadata adapter", "[structured]") {
     SECTION("Metadata size limits") {
         // Try to add data that would collide with text area
         // Fill text area to leave minimal space
-        std::string text(LOG_BUFFER_SIZE - 100, 'x');
+        std::string text(buffer_pool::BUFFER_SIZE - 100, 'x');
         buffer->write_raw(text);
         
         // Now try to add metadata that won't fit


### PR DESCRIPTION
## Summary
- Refactored log_buffer into base class + templated derived class pattern for better type safety
- Fixed metadata iterator bug that was reading uninitialized memory
- Added comprehensive safety improvements and compile-time checks

## Key Changes

### Architecture Refactoring
- Split `log_buffer` into:
  - `log_buffer_base`: Contains all logic, uses `char* data_` pointer
  - `log_buffer<Size>`: Templated class providing aligned storage
- Hid `LOG_BUFFER_SIZE` constant from public API (now only accessible via `buffer_pool::BUFFER_SIZE`)

### Safety Improvements
- ✅ Prevented default construction (buffers must go through pool)
- ✅ Deleted copy/move operations to prevent aliasing issues  
- ✅ Added cache-line alignment for performance
- ✅ Added static assertions for compile-time validation
- ✅ Added noexcept specifications throughout
- ✅ Fixed initialization order using inheritance pattern

### Bug Fix
- 🐛 Fixed metadata iterator reading past actual KV pairs into uninitialized memory
- Iterator now properly respects the count byte and stops after reading the specified number of pairs

### API Updates
- Changed all `log_buffer*` references to `log_buffer_base*`
- Updated tests to use `buffer_pool::BUFFER_SIZE`
- Updated forward declarations throughout codebase

## Test Plan
- [x] All existing tests pass
- [x] Sanitizer checks pass (ASan + UBSan)
- [x] Smoke tests pass
- [x] Verified garbled output issue is fixed