### PR TITLE
Add amalgamation support for release branches

### DIFF
--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*'
   
-  # Allow manual triggering
+  # Allow manual triggering (for testing purposes only)
   workflow_dispatch:
     inputs:
       release_type:
@@ -26,22 +26,108 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Need full history for git describe to work
+          # Need full history for git describe to work and to verify tag type
           fetch-depth: 0
           # Initialize submodules for dependencies
           submodules: recursive
       
+      - name: Verify release conditions
+        id: verify
+        run: |
+          echo "=== Verifying release conditions ==="
+          
+          # Get the current tag name
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          echo "Current tag: $TAG_NAME"
+          
+          # Check if this is an annotated tag
+          if git describe --exact-match --tags 2>/dev/null | grep -q "^$TAG_NAME$"; then
+            # Check if it's annotated (will fail for lightweight tags)
+            if git cat-file -p "$TAG_NAME" 2>/dev/null | grep -q "^tag "; then
+              echo "✓ Tag is annotated"
+              IS_ANNOTATED="true"
+            else
+              echo "✗ Tag is lightweight (not annotated)"
+              IS_ANNOTATED="false"
+            fi
+          else
+            echo "✗ Not on a tag"
+            IS_ANNOTATED="false"
+          fi
+          
+          # Get the branch name that contains this tag
+          BRANCHES=$(git branch -r --contains "$TAG_NAME" | grep -v HEAD | sed 's/.*origin\///')
+          echo "Branches containing this tag:"
+          echo "$BRANCHES"
+          
+          # Check if tag is on a proper release branch
+          # Pattern: version-X.Y or release-X.Y or release/X.Y or version/X.Y
+          VALID_BRANCH="false"
+          for BRANCH in $BRANCHES; do
+            if echo "$BRANCH" | grep -qE '^(version|release)[-/][0-9]+\.[0-9]+$'; then
+              echo "✓ Found valid release branch: $BRANCH"
+              VALID_BRANCH="true"
+              RELEASE_BRANCH="$BRANCH"
+              break
+            fi
+          done
+          
+          if [ "$VALID_BRANCH" = "false" ]; then
+            echo "✗ Tag is not on a properly named release branch"
+            echo "  Expected pattern: version-X.Y or release-X.Y"
+          fi
+          
+          # Verify tag format matches branch version
+          if [ "$VALID_BRANCH" = "true" ]; then
+            # Extract version from branch name (e.g., version-0.1 -> 0.1)
+            BRANCH_VERSION=$(echo "$RELEASE_BRANCH" | sed -E 's/^(version|release)[-\/]//')
+            
+            # Check if tag starts with v followed by the branch version
+            if echo "$TAG_NAME" | grep -qE "^v${BRANCH_VERSION}\.[0-9]+"; then
+              echo "✓ Tag version matches branch version"
+              VERSION_MATCH="true"
+            else
+              echo "✗ Tag $TAG_NAME doesn't match branch version $BRANCH_VERSION"
+              echo "  Expected pattern: v${BRANCH_VERSION}.x"
+              VERSION_MATCH="false"
+            fi
+          else
+            VERSION_MATCH="false"
+          fi
+          
+          # Final decision
+          if [ "$IS_ANNOTATED" = "true" ] && [ "$VALID_BRANCH" = "true" ] && [ "$VERSION_MATCH" = "true" ]; then
+            echo ""
+            echo "=== All release conditions met ✓ ==="
+            echo "proceed=true" >> $GITHUB_OUTPUT
+            echo "branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo ""
+            echo "=== Release conditions NOT met ✗ ==="
+            echo "Requirements:"
+            echo "  1. Tag must be annotated (git tag -a)"
+            echo "  2. Tag must be on a release branch (version-X.Y or release-X.Y)"
+            echo "  3. Tag version must match branch (e.g., v0.1.x for version-0.1)"
+            echo ""
+            echo "Skipping amalgamation build for main branch"
+            echo "proceed=false" >> $GITHUB_OUTPUT
+            exit 0  # Exit successfully but skip remaining steps
+          fi
+      
       - name: Setup Python
+        if: steps.verify.outputs.proceed == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       
       - name: Install dependencies
+        if: steps.verify.outputs.proceed == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y g++ python3
       
       - name: Generate amalgamation
+        if: steps.verify.outputs.proceed == 'true'
         run: |
           echo "Creating slwoggy amalgamation build..."
           ./create-amalgamation.sh
@@ -59,6 +145,7 @@ jobs:
           echo "  Lines: $(wc -l < amalgamation/slwoggy.hpp) lines"
       
       - name: Get version info
+        if: steps.verify.outputs.proceed == 'true'
         id: version
         run: |
           VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -76,6 +163,7 @@ jobs:
           fi
       
       - name: Create build package
+        if: steps.verify.outputs.proceed == 'true'
         run: |
           # Create a clean directory for the build
           mkdir -p slwoggy-build
@@ -173,14 +261,54 @@ jobs:
           ls -la slwoggy-build/
       
       - name: Upload build artifact
+        if: steps.verify.outputs.proceed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.version.outputs.artifact_name }}
           path: slwoggy-build/
           retention-days: 90
       
+      - name: Commit amalgamation to release branch
+        if: steps.verify.outputs.proceed == 'true'
+        run: |
+          echo "Committing amalgamation to release branch: ${{ steps.verify.outputs.branch }}"
+          
+          # Configure git
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          
+          # Switch to the release branch
+          git checkout "${{ steps.verify.outputs.branch }}"
+          
+          # Check if amalgamation directory already exists
+          if [ -d "amalgamation" ]; then
+            echo "Updating existing amalgamation..."
+          else
+            echo "Creating new amalgamation directory..."
+          fi
+          
+          # Copy the generated amalgamation
+          cp -r amalgamation amalgamation.new
+          rm -rf amalgamation
+          mv amalgamation.new amalgamation
+          
+          # Add and commit if there are changes
+          git add amalgamation/
+          if git diff --staged --quiet; then
+            echo "No changes to amalgamation, skipping commit"
+          else
+            git commit -m "Update amalgamation for ${{ steps.version.outputs.version }}
+            
+            Generated from tag ${{ steps.version.outputs.version }}
+            [skip ci]"
+            
+            # Push to the release branch
+            git push origin "${{ steps.verify.outputs.branch }}"
+            echo "✓ Amalgamation committed to ${{ steps.verify.outputs.branch }}"
+          fi
+      
       - name: Create release (for tagged versions)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: steps.verify.outputs.proceed == 'true' && startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
           files: |

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -56,7 +56,10 @@ jobs:
           fi
           
           # Get the branch name that contains this tag
-          BRANCHES=$(git branch -r --contains "$TAG_NAME" | grep -v HEAD | sed 's/.*origin\///')
+          # Get the commit hash that the tag points to
+          TAG_COMMIT=$(git rev-parse "$TAG_NAME")
+          # Get the branch name that contains this tag's commit
+          BRANCHES=$(git branch -r --contains "$TAG_COMMIT" | grep -v HEAD | sed 's/.*origin\///')
           echo "Branches containing this tag:"
           echo "$BRANCHES"
           

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -273,24 +273,42 @@ jobs:
         run: |
           echo "Committing amalgamation to release branch: ${{ steps.verify.outputs.branch }}"
           
+          # Validate branch name format for safety
+          if ! echo "${{ steps.verify.outputs.branch }}" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+            echo "Error: Invalid branch name format"
+            exit 1
+          fi
+          
           # Configure git
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           
-          # Switch to the release branch
-          git checkout "${{ steps.verify.outputs.branch }}"
+          # Save the generated amalgamation before switching branches
+          if [ -d "amalgamation" ]; then
+            echo "Saving generated amalgamation..."
+            cp -r amalgamation /tmp/amalgamation.generated
+          else
+            echo "Error: amalgamation directory not found after generation"
+            exit 1
+          fi
           
-          # Check if amalgamation directory already exists
+          # Fetch latest remote refs
+          git fetch origin
+          
+          # Switch to the release branch (create local tracking branch if needed)
+          git checkout -B "${{ steps.verify.outputs.branch }}" "origin/${{ steps.verify.outputs.branch }}"
+          
+          # Safely replace amalgamation directory
           if [ -d "amalgamation" ]; then
             echo "Updating existing amalgamation..."
+            rm -rf amalgamation.backup
+            mv amalgamation amalgamation.backup
           else
             echo "Creating new amalgamation directory..."
           fi
           
-          # Copy the generated amalgamation
-          cp -r amalgamation amalgamation.new
-          rm -rf amalgamation
-          mv amalgamation.new amalgamation
+          # Move the generated amalgamation into place
+          mv /tmp/amalgamation.generated amalgamation
           
           # Add and commit if there are changes
           git add amalgamation/

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -41,7 +41,7 @@ jobs:
           echo "Current tag: $TAG_NAME"
           
           # Check if this is an annotated tag
-          if git describe --exact-match --tags 2>/dev/null | grep -q "^$TAG_NAME$"; then
+          if git tag --points-at HEAD | grep -q "^$TAG_NAME$"; then
             # Check if it's annotated by checking the object type
             if [ "$(git cat-file -t "$TAG_NAME" 2>/dev/null)" = "tag" ]; then
               echo "✓ Tag is annotated"

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -42,8 +42,8 @@ jobs:
           
           # Check if this is an annotated tag
           if git describe --exact-match --tags 2>/dev/null | grep -q "^$TAG_NAME$"; then
-            # Check if it's annotated (will fail for lightweight tags)
-            if git cat-file -p "$TAG_NAME" 2>/dev/null | grep -q "^tag "; then
+            # Check if it's annotated by checking the object type
+            if [ "$(git cat-file -t "$TAG_NAME" 2>/dev/null)" = "tag" ]; then
               echo "✓ Tag is annotated"
               IS_ANNOTATED="true"
             else
@@ -315,10 +315,14 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to amalgamation, skipping commit"
           else
-            git commit -m "Update amalgamation for ${{ steps.version.outputs.version }}
-            
-            Generated from tag ${{ steps.version.outputs.version }}
-            [skip ci]"
+            # Use heredoc for proper multi-line commit message
+            cat > /tmp/commit_msg <<EOF
+          Update amalgamation for ${{ steps.version.outputs.version }}
+          
+          Generated from tag ${{ steps.version.outputs.version }}
+          [skip ci]
+          EOF
+            git commit -F /tmp/commit_msg
             
             # Push to the release branch
             git push origin "${{ steps.verify.outputs.branch }}"

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -286,14 +286,20 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           
-          # Save the generated amalgamation before switching branches
-          if [ -d "amalgamation" ]; then
-            echo "Saving generated amalgamation..."
-            cp -r amalgamation /tmp/amalgamation.generated
-          else
+          # Validate that amalgamation was actually created
+          if [ ! -d "amalgamation" ]; then
             echo "Error: amalgamation directory not found after generation"
             exit 1
           fi
+          
+          if [ ! -f "amalgamation/slwoggy.hpp" ]; then
+            echo "Error: amalgamation/slwoggy.hpp not found"
+            exit 1
+          fi
+          
+          # Save the generated amalgamation before switching branches
+          echo "Saving generated amalgamation..."
+          cp -r amalgamation /tmp/amalgamation.generated
           
           # Fetch latest remote refs
           git fetch origin

--- a/.github/workflows/amalgamation-build.yml
+++ b/.github/workflows/amalgamation-build.yml
@@ -322,7 +322,8 @@ jobs:
           Generated from tag ${{ steps.version.outputs.version }}
           [skip ci]
           EOF
-            git commit -F /tmp/commit_msg
+            # Use single-line commit message to avoid YAML heredoc indentation issues
+            git commit -m "Update amalgamation for ${{ steps.version.outputs.version }} [skip ci]"
             
             # Push to the release branch
             git push origin "${{ steps.verify.outputs.branch }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,19 @@ endif()
 add_library(slwoggy INTERFACE)
 add_library(slwoggy::slwoggy ALIAS slwoggy)
 
-# Set include directories (build interface only - no installation support)
-target_include_directories(slwoggy INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
+# Check if amalgamation directory exists
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/amalgamation" AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/amalgamation")
+    # Use amalgamation directory if it exists (single-header mode)
+    message(STATUS "Using amalgamation directory for include path")
+    target_include_directories(slwoggy INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/amalgamation>
+    )
+else()
+    # Use standard include directory (multi-header mode)
+    target_include_directories(slwoggy INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    )
+endif()
 
 # Propagate include directories from dependencies
 target_link_libraries(slwoggy INTERFACE 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Then in your code:
 using namespace slwoggy;
 
 int main() {
-    log_line_dispatcher::instance().add_sink(make_stdout_sink());
     LOG(info) << "Hello from slwoggy!" << endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- Adds automatic amalgamation directory detection to CMakeLists.txt
- Enhances GitHub Actions workflow to enforce strict release branch requirements
- Ensures amalgamation only exists on properly tagged release branches, never on main

## Changes

### CMakeLists.txt
- Automatically detects if `amalgamation/` directory exists
- Uses it as include path for single-header mode when present
- Falls back to `include/` for standard multi-header mode
- Provides seamless integration for downstream projects

### GitHub Actions Workflow (amalgamation-build.yml)
- **Strict validation**: Only builds amalgamation for annotated tags on release branches
- **Branch patterns**: Supports `version-X.Y` and `release-X.Y` naming
- **Version matching**: Ensures tag version (e.g., v0.1.3) matches branch (e.g., version-0.1)
- **Auto-commit**: Commits amalgamation to release branch after generation
- **Main protection**: Prevents amalgamation from ever appearing on main branch

## Test Plan
- [x] CMake correctly detects amalgamation directory when present
- [x] CMake falls back to include/ when amalgamation missing
- [x] Workflow validation logic tested with various scenarios
- [x] Generated amalgamation compiles successfully

## Release Strategy
This setup enables a clean release workflow:
1. Development happens on main (no amalgamation)
2. Create release branch (e.g., `version-0.1`)
3. Tag releases with annotated tags (e.g., `git tag -a v0.1.0`)
4. GitHub Actions automatically generates and commits amalgamation to release branch
5. Main branch stays clean for development